### PR TITLE
Trampolining

### DIFF
--- a/src/main/scala/effekt/Control.scala
+++ b/src/main/scala/effekt/Control.scala
@@ -45,22 +45,22 @@ sealed trait Control[+A] { outer =>
    * Attention: It is unsafe to run control if not all effects have
    *            been handled!
    */
-  def run(): A = apply(ReturnCont(identity))
+  def run(): A = Result.trampoline(apply(ReturnCont(identity)))
 
   def map[B](f: A => B): Control[B] = new Control[B] {
-    def apply[R](k: MetaCont[B, R]): R = outer(k map f)
+    def apply[R](k: MetaCont[B, R]): Result[R] = outer(k map f)
   }
 
   def flatMap[B](f: A => Control[B]): Control[B] = new Control[B] {
-    def apply[R](k: MetaCont[B, R]): R = outer(k flatMap f)
+    def apply[R](k: MetaCont[B, R]): Result[R] = outer(k flatMap f)
   }
 
-  private[effekt] def apply[R](k: MetaCont[A, R]): R
+  private[effekt] def apply[R](k: MetaCont[A, R]): Result[R]
 }
 
 private[effekt]
 final class Trivial[+A](a: A) extends Control[A] {
-  def apply[R](k: MetaCont[A, R]): R = k(a)
+  def apply[R](k: MetaCont[A, R]): Result[R] = k(a)
 
   override def map[B](f: A => B): Control[B] = new Trivial(f(a))
 
@@ -100,14 +100,14 @@ object Control {
   private[effekt] final def use[A](c: Capability)(
     f: c.effect.State => (A => c.effect.State => Control[c.Res]) => Control[c.Res]
   ): Control[A] = new Control[A] {
-    def apply[R](k: MetaCont[A, R]): R = {
+    def apply[R](k: MetaCont[A, R]): Result[R] = {
 
       // slice the meta continuation in three parts
       val (init, h, tail) = k splitAt c
 
       val localCont: A => c.effect.State => Control[c.Res] =
         a => updatedState => new Control[c.Res] {
-          def apply[R2](k: MetaCont[c.Res, R2]): R2 = {
+          def apply[R2](k: MetaCont[c.Res, R2]): Result[R2] = {
 
             // create a copy of the handler with the very same prompt but
             // updated state
@@ -127,7 +127,7 @@ object Control {
       val handled: Control[c.Res] = f(h.state)(localCont)
 
       // continue with tail
-      handled(tail)
+      Impure(handled, tail)
     }
   }
 
@@ -145,11 +145,11 @@ object Control {
     }
 
     new Control[e.Out[R]] {
-      def apply[R2](k: MetaCont[e.Out[R], R2]): R2 = {
+      def apply[R2](k: MetaCont[e.Out[R], R2]): Result[R2] = {
         // extract new state
         val c = f(p).flatMap{ a =>
           new Control[e.Out[R]] {
-            def apply[R3](k: MetaCont[e.Out[R], R3]): R3 = {
+            def apply[R3](k: MetaCont[e.Out[R], R3]): Result[R3] = {
               (k: @unchecked) match {
                 // Invariant: The last continuation on the metacont stack is a HandlerCont for p
                 case HandlerCont(h2: H[p.type] @unchecked, k2) => {

--- a/src/main/scala/effekt/Control.scala
+++ b/src/main/scala/effekt/Control.scala
@@ -159,7 +159,7 @@ object Control {
             }
           }
         }
-        c(HandlerCont(h, k))
+        Impure(c, HandlerCont(h, k))
       }
     }
   }

--- a/src/main/scala/effekt/MetaCont.scala
+++ b/src/main/scala/effekt/MetaCont.scala
@@ -37,7 +37,7 @@ case class CastCont[-A, +B]() extends MetaCont[A, B] {
 
 private[effekt]
 case class FrameCont[-A, B, +C](frame: Frame[A, B], tail: MetaCont[B, C]) extends MetaCont[A, C] {
-  final def apply(a: A): Result[C] = frame(a)(tail)
+  final def apply(a: A): Result[C] = Impure(frame(a), tail)
 
   final def append[D](s: MetaCont[C, D]): MetaCont[A, D] = (tail append s) flatMap frame
 

--- a/src/main/scala/effekt/MetaCont.scala
+++ b/src/main/scala/effekt/MetaCont.scala
@@ -2,7 +2,7 @@ package effekt
 
 private[effekt]
 sealed trait MetaCont[-A, +B] extends Serializable {
-  def apply(a: A): B
+  def apply(a: A): Result[B]
 
   def append[C](s: MetaCont[B, C]): MetaCont[A, C]
 
@@ -15,7 +15,7 @@ sealed trait MetaCont[-A, +B] extends Serializable {
 
 private[effekt]
 case class ReturnCont[-A, +B](f: A => B) extends MetaCont[A, B] {
-  final def apply(a: A): B = f(a)
+  final def apply(a: A): Result[B] = Pure(f(a))
 
   final def append[C](s: MetaCont[B, C]): MetaCont[A, C] = s map f
 
@@ -26,7 +26,7 @@ case class ReturnCont[-A, +B](f: A => B) extends MetaCont[A, B] {
 
 private[effekt]
 case class CastCont[-A, +B]() extends MetaCont[A, B] {
-  final def apply(a: A): B = a.asInstanceOf[B]
+  final def apply(a: A): Result[B] = Pure(a.asInstanceOf[B])
 
   final def append[C](s: MetaCont[B, C]): MetaCont[A, C] = s.asInstanceOf[MetaCont[A, C]]
 
@@ -37,7 +37,7 @@ case class CastCont[-A, +B]() extends MetaCont[A, B] {
 
 private[effekt]
 case class FrameCont[-A, B, +C](frame: Frame[A, B], tail: MetaCont[B, C]) extends MetaCont[A, C] {
-  final def apply(a: A): C = frame(a)(tail)
+  final def apply(a: A): Result[C] = frame(a)(tail)
 
   final def append[D](s: MetaCont[C, D]): MetaCont[A, D] = (tail append s) flatMap frame
 
@@ -53,7 +53,7 @@ case class FrameCont[-A, B, +C](frame: Frame[A, B], tail: MetaCont[B, C]) extend
 
 private[effekt]
 case class HandlerCont[R, A](h: Handler {type Res = R}, tail: MetaCont[R, A]) extends MetaCont[R, A] {
-  final def apply(r: R): A = tail(r)
+  final def apply(r: R): Result[A] = tail(r)
 
   final def append[C](s: MetaCont[A, C]): MetaCont[R, C] = HandlerCont(h, tail append s)
 

--- a/src/main/scala/effekt/Result.scala
+++ b/src/main/scala/effekt/Result.scala
@@ -1,0 +1,19 @@
+package effekt
+
+private[effekt]
+sealed trait Result[+A]
+
+private[effekt]
+case class Pure[A](value: A) extends Result[A]
+
+private[effekt]
+case class Impure[A, R](c: Control[R], k: MetaCont[R, A]) extends Result[A]
+
+private[effekt]
+object Result {
+  @scala.annotation.tailrec
+  def trampoline[A](y: Result[A]): A = y match {
+    case Pure(a) => a
+    case Impure(c, k) => trampoline[A](c(k))
+  }
+}


### PR DESCRIPTION
This PR adds a simple form of trampolining to save runtime stack.

Judging from simple performance measurements (counting down using state and the n-queens benchmark) this PR does not effect performance, but only saves stack space. In particular the n-queens problem finally can be solved for n > 8.