### PR TITLE
Fix link to first effect tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ following line to your `build.sbt` file:
 libraryDependencies += "de.b-studios" %% "effekt" % "0.1-SNAPSHOT"
 ```
 
-To learn how to use the library, see [Your First Effect](http://b-studios.de/scala-effekt/first-effect.html).
+To learn how to use the library, see [Your First Effect](http://b-studios.de/scala-effekt/guides/getting-started.html).

--- a/docs/src/main/tut/design.md
+++ b/docs/src/main/tut/design.md
@@ -29,7 +29,7 @@ def prog(implicit amb: Use[Amb]): Control[Int] =
   amb.flip() map { x => if (x) 2 else 3 }
 ```
 (**ATTENTION**: The above code is a slight simplification, only for
-illustrative purposes. For real code see [Your First Effect](./first-effect.html))
+illustrative purposes. For real code see [Your First Effect](./guides/getting-started.html))
 
 As can be seen above, **Effekt** uses implicit arguments to pass down
 handler implementations to the use-site (`flip`).

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -72,4 +72,4 @@ following line to your `build.sbt` file:
 libraryDependencies += "de.b-studios" %% "effekt" % "0.1-SNAPSHOT"
 ```
 
-To learn how to use the library, see [Your First Effect](./first-effect.html).
+To learn how to use the library, see [Your First Effect](./guides/getting-started.html).


### PR DESCRIPTION
Old links were broken due to renaming. See #3 