### PR TITLE
Interaction between algebraic handlers and native exceptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.sbtplugin.cross.CrossProject
 
 lazy val commonSettings = Seq(
   scalaVersion := "2.12.2",
-  version := "0.2-SNAPSHOT",
+  version := "0.3-SNAPSHOT",
   organization := "de.b-studios",
   crossScalaVersions := Seq("2.11.8", "2.12.1"),
   scalacOptions ++= Seq(

--- a/effects/src/main/scala/effekt/effects/Exc.scala
+++ b/effects/src/main/scala/effekt/effects/Exc.scala
@@ -1,0 +1,30 @@
+package effekt
+package effects
+
+trait Exc extends Eff {
+  def raise[A](msg: String): Op[A]
+}
+object Exc {
+
+  def raise[A](msg: String)(implicit u: Use[Exc]): Control[A] =
+    use(u)(u.handler.raise[A](msg))
+
+  def excOption[R] = new Handler.Basic[R, Option[R]] with Exc {
+    def unit = a => Some(a)
+    def raise[A](msg: String) = _ => resume => pure(None)
+  }
+
+  def fromException[R](filter: Exception => Boolean = _ => true) =
+    new Handler.Basic[R, Either[Exception, R]] with Exc {
+      def unit = a => Right(a)
+      def raise[A](msg: String) = _ => resume => pure(Left(new Exception(msg)))
+      override def _catch = {
+        case e: Exception if filter(e) => pure(Left(e))
+      }
+    }
+
+  def toException[R](c: Either[Exception, R]): R = c match {
+    case Left(e) => throw e
+    case Right(r) => r
+  }
+}

--- a/shared/src/main/scala/effekt/Control.scala
+++ b/shared/src/main/scala/effekt/Control.scala
@@ -168,7 +168,7 @@ object Control {
       }
 
       // initial handler frame
-      val hf = HandlerFrame(p)(init, List(h.cleanup))
+      val hf = HandlerFrame(p)(init, List(h._finally))
 
       Impure(c, HandlerCont(hf, k))
     }

--- a/shared/src/main/scala/effekt/Control.scala
+++ b/shared/src/main/scala/effekt/Control.scala
@@ -155,13 +155,13 @@ object Control {
             case HandlerCont(h2: HandlerFrame.Aux[p.type] @unchecked, k2) => {
               // after lifting a into the result type of the handler, perform
               // a resource cleanup.
-              val res = h.unit(a)
+              val res = h.unitState(h2.state)(a)
               h2.cleanup()
 
               // now continue
               // for now wrapped in Trivial to allow trampolining and
               // ressource cleanup
-              Impure(pure(res), k2)
+              Impure(res, k2)
             }
           }
         }

--- a/shared/src/main/scala/effekt/Control.scala
+++ b/shared/src/main/scala/effekt/Control.scala
@@ -51,6 +51,12 @@ sealed trait Control[+A] { outer =>
 
   def flatMap[B](f: A => Control[B]): Control[B] = Computation { k => Impure(outer, k flatMap f) }
 
+  def andThen[B](f: Control[B]): Control[B] = flatMap(_ => f)
+
+  def >>=[B](f: A => Control[B]): Control[B] = flatMap(f)
+
+  def >>[B](f: Control[B]): Control[B] = andThen(f)
+
   private[effekt] def apply[R](k: MetaCont[A, R]): Result[R]
 }
 

--- a/shared/src/main/scala/effekt/Handler.scala
+++ b/shared/src/main/scala/effekt/Handler.scala
@@ -28,10 +28,12 @@ trait Handler extends Eff { outer =>
 
   def unit: R => Res
 
+  def _catch: PartialFunction[Throwable, Control[Res]] = PartialFunction.empty
+
   /**
    * Handlers may perform cleanup actions (similar to finally-clauses).
    */
-  def cleanup: () => Unit = Handler.noCleanup
+  def _finally: () => Unit = Handler.noCleanup
 
   def apply(init: State)(f: Capability { val handler: outer.type } => Control[R]): Control[Res] =
     effekt.handle(this)(init)(f)

--- a/shared/src/main/scala/effekt/Handler.scala
+++ b/shared/src/main/scala/effekt/Handler.scala
@@ -28,6 +28,8 @@ trait Handler extends Eff { outer =>
 
   def unit: R => Res
 
+  def unitState: State => R => Control[Res] = _ => r => pure(unit(r))
+
   def _catch: PartialFunction[Throwable, Control[Res]] = PartialFunction.empty
 
   /**

--- a/shared/src/main/scala/effekt/Result.scala
+++ b/shared/src/main/scala/effekt/Result.scala
@@ -24,7 +24,7 @@ object Result {
     while (!res.isPure) {
       val imp = res.asInstanceOf[Impure[A, Any]]
       try { res = imp.c(imp.k) } catch {
-        case e: Throwable => imp.k.unwind(); throw e
+        case e: Throwable => res = imp.k.unwind(e)
       }
     }
     res.asInstanceOf[Pure[A]].value


### PR DESCRIPTION
This PR adds a more uniform way to interact with native exceptions. Handlers can override methods `_catch` and `_finally` which are called when the meta continuation is unwinded and handler continuations are popped.